### PR TITLE
Added Sourcegraph API token param

### DIFF
--- a/module_dependencies/module/module.py
+++ b/module_dependencies/module/module.py
@@ -2,6 +2,7 @@ import logging
 import warnings
 from collections import Counter, defaultdict
 from functools import lru_cache
+from typing import Optional
 
 try:
     from functools import cached_property
@@ -19,11 +20,12 @@ class Module:
     def __init__(
         self,
         module: str,
+        token: Optional[str] = None,
         count: Union[int, str] = "25000",
         verbose: bool = True,
         lazy: bool = True,
         python: bool = True,
-        jupyter: bool = True,
+        jupyter: bool = True
     ) -> None:
         """Create a Module instance that can be used to find
         which sections of a Python module are most frequently used.
@@ -51,6 +53,8 @@ class Module:
         :param module: The name of a Python module of which to find
             the frequently used objects, e.g. `"nltk"`.
         :type module: str
+        :param token: Sourcegraph API token to avoid rate-limiting 429 error
+        :type token: str, optional
         :param count: The maximum number of times an import of `module`
             should be fetched. Roughly equivalent to the number of fetched
             files. Either an integer, a string representing an integer,
@@ -68,7 +72,8 @@ class Module:
         self.count = count
         self.timeout = "10s"
         self.verbose = verbose
-
+        self.token = token
+        
         languages = []
         if python:
             languages.append("Python")
@@ -110,7 +115,7 @@ class Module:
         :return: The cached, parsed SourceGraph API data.
         :rtype: Dict
         """
-        return ModuleSession().fetch_and_parse(
+        return ModuleSession(token=self.token).fetch_and_parse(
             self.module, self.count, self.timeout, self.verbose, self.languages
         )
 

--- a/module_dependencies/module/session.py
+++ b/module_dependencies/module/session.py
@@ -275,5 +275,4 @@ class ModuleSession(requests.Session):
         if self.token is not None:
             logger.info('Using Sourcegraph API token')
             return super().post(self.url, json=payload, headers={"Authorization": f"token {self.token}"})
-        else:
-            return super().post(self.url, json=payload)
+        return super().post(self.url, json=payload)


### PR DESCRIPTION
Issue: Rate limiting of Sourcegraph API results in a 429 response, `HTTPError: 429 Client Error: Too Many Requests for url: https://sourcegraph.com/.api/graphql`

Resolution: Added optional `token` parameter for `Module` and `ModuleSession` constructors to provide [Sourcegraph API token](https://docs.sourcegraph.com/cli/how-tos/creating_an_access_token), which will be included in request headers.